### PR TITLE
Made the spawning process agnostic to user shell by wrapping in bash -c

### DIFF
--- a/scripts/get_port.py
+++ b/scripts/get_port.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # Gets a random unused port
 

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -96,6 +96,13 @@ class SSHSpawner(Spawner):
         return self.gsi_key_path.replace("%U", self.user.name)
 
     def execute(self, command=None, stdin=None):
+        """
+        command: command to execute  (via bash -c command)
+        stdin: script to pass in via stdin (via 'bash -s' < stdin)
+
+        executes command on remote system "command" and "stdin" are mutually exclusive
+
+        """
         ssh_env = os.environ.copy()
 
         username = self.get_remote_user(self.user.name)
@@ -168,7 +175,7 @@ class SSHSpawner(Spawner):
 
     def exec_notebook(self, command):
         env = self.user_env()
-        bash_script_str = "#!/bin/bash"
+        bash_script_str = "#!/bin/bash\n"
 
         for item in env.items():
             # item is a (key, value) tuple

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -208,7 +208,7 @@ class SSHSpawner(Spawner):
         self.log.debug("Entering start")
 
         port = self.remote_random_port()
-	if port is None or port==0:
+        if port is None or port==0:
             return False
         cmd = []
 

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -137,6 +137,7 @@ class SSHSpawner(Spawner):
             JPY_COOKIE_NAME=self.user.server.cookie_name,
             JPY_BASE_URL=self.user.server.base_url,
             JPY_HUB_PREFIX=self.hub.server.base_url,
+            JUPYTERHUB_PREFIX=self.hub.server.base_url,
             # PATH=self.path
             # NERSC local mod
             PATH=self.path
@@ -150,6 +151,7 @@ class SSHSpawner(Spawner):
             hub_api_url = self.hub_api_url
 
         env['JPY_HUB_API_URL'] = hub_api_url
+        env['JUPYTERHUB_API_URL'] = hub_api_url
 
         return env
 
@@ -205,11 +207,8 @@ class SSHSpawner(Spawner):
         """Start the process"""
         self.log.debug("Entering start")
 
-        self.user.server.ip = self.remote_host
         port = self.remote_random_port()
-        if port is not None and port > 0:
-            self.user.server.port = port
-        else:
+	if port is None or port==0:
             return False
         cmd = []
 
@@ -222,6 +221,9 @@ class SSHSpawner(Spawner):
             for index, value in enumerate(cmd):
                 if value == old:
                     cmd[index] = new
+        for index, value in enumerate(cmd):
+            if value[0:6] == '--port':
+                cmd[index] = '--port=%d' % (port)
 
         remote_cmd = ' '.join(cmd)
 
@@ -234,6 +236,7 @@ class SSHSpawner(Spawner):
 
         if self.pid < 0:
             return None
+        return (self.remote_host, port)
 
     @gen.coroutine
     def poll(self):

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -182,11 +182,11 @@ class SSHSpawner(Spawner):
         # Finally Grab the PID
         # command = '"%s" < /dev/null >> jupyter.log 2>&1 & pid=$!; echo $pid' % command
 
-        bash_script_str += '%s < /dev/null >> jupyter.log 2>&1 & pid=$!' % command
-        bash_script_str += 'echo $pid'
+        bash_script_str += '%s < /dev/null >> jupyter.log 2>&1 & pid=$!\n' % command
+        bash_script_str += 'echo $pid\n'
 
         run_script = "/tmp/{}_run.sh".format(self.user.name)
-        with open(run_script) as f:
+        with open(run_script, "w") as f:
             f.write(bash_script_str)
 
         stdout, stderr, retcode = self.execute(command, stdin=run_script)

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -27,9 +27,11 @@ class SSHSpawner(Spawner):
                    """
                    ).tag(config=True)
 
-    remote_port_command = Unicode("python -c \"import socket; sock = socket.socket(); sock.bind(('', 0)); print sock.getsockname()[1]; sock.close()\"",
+    remote_port_command = Unicode("/usr/local/bin/get_port.py",
                                   help="""The command to return an unused port
-                                  on the remote node
+                                  on the remote node. 
+                                  Copy from scripts/get_port.py to 
+                                  /usr/local/bin/ on the remote node 
                                   """
                                   ).tag(config=True)
 
@@ -110,7 +112,9 @@ class SSHSpawner(Spawner):
         elif self.ssh_keyfile:
             ssh_args += " -i {keyfile}".format(keyfile=self.ssh_keyfile)
 
-        command = "{ssh_command} {flags} {hostname} {command}".format(
+        # This is not very good at handling nested quotes - avoid using quotes in 
+        # the command and use wrapper scripts as much as possible 
+        command = "{ssh_command} {flags} {hostname} bash -c '{command}'".format(
             ssh_command=self.ssh_command,
             flags=ssh_args,
             hostname=self.remote_host,
@@ -158,12 +162,16 @@ class SSHSpawner(Spawner):
     def exec_notebook(self, command):
         env = self.user_env()
         for item in env.items():
-            command = ('export %s="%s";' % item) + command
+            # item is a (key, value) tuple
+            command = ('export %s=%s;' % item) + command
 
-        # The command needs to be wrapped in quotes
-        # We pass in stdin to avoid the hang
-        # Grab the PID
-        command = "'%s < /dev/null >> jupyter.log 2>&1 & pid=$!; echo $pid'" % command
+
+        # pass this into bash -c 'command'
+        # command needs to be in "" quotes, with all the redirection outside
+        # eg. bash -c '"ls -la" < /dev/null >> out.txt'
+        # We pass in /dev/null to stdin to avoid the hang
+        # Finally Grab the PID
+        command = '"%s" < /dev/null >> jupyter.log 2>&1 & pid=$!; echo $pid' % command
 
         stdout, stderr, retcode = self.execute(command)
         self.log.debug("exec_notebook status={}".format(retcode))
@@ -179,7 +187,11 @@ class SSHSpawner(Spawner):
         # NERSC local mod
         command = self.remote_port_command
 
-        command = command + "< /dev/null"
+        # pass this into bash -c 'command'
+        # command needs to be in "" quotes, with all the redirection outside
+        # eg. bash -c '"ls -la" < /dev/null >> out.txt'
+        command = '"%s" < /dev/null' % command
+
         stdout, stderr, retcode = self.execute(command)
 
         if stdout != b'':
@@ -197,7 +209,10 @@ class SSHSpawner(Spawner):
         """
         command = 'kill -s %s %d' % (sig, self.pid)
 
-        command = command + "< /dev/null"
+        # pass this into bash -c 'command'
+        # command needs to be in "" quotes, with all the redirection outside
+        # eg. bash -c '"ls -la" < /dev/null >> out.txt'
+        command = '"%s" < /dev/null' % command
 
         stdout, stderr, retcode = self.execute(command)
         return (retcode == 0)

--- a/version.py
+++ b/version.py
@@ -4,7 +4,7 @@
 version_info = (
     0,
     0,
-    1,
+    2,
 )
 __version__ = '.'.join(map(str, version_info[:3]))
 

--- a/version.py
+++ b/version.py
@@ -4,7 +4,7 @@
 version_info = (
     0,
     0,
-    2,
+    3,
 )
 __version__ = '.'.join(map(str, version_info[:3]))
 


### PR DESCRIPTION
This is a somewhat tricky bug. We basically need to wrap everything in `bash -c 'command'`. The tricky thing about bash -c is that that actual command has to be in "" with all the bash redirection outside the double quotes.
eg.
```
bash -c '"ls -la" < /dev/null >> out.txt'
```