### PR TITLE
Add return code logging for remote signal call

### DIFF
--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -238,6 +238,7 @@ class SSHSpawner(Spawner):
         command = '"%s" < /dev/null' % command
 
         stdout, stderr, retcode = self.execute(command)
+        self.log.debug("command: {} returned {}".format(command, retcode))
         return (retcode == 0)
 
     @gen.coroutine


### PR DESCRIPTION
We are still getting duplicate servers.  If gsissh fails for some reason
then this is going to trigger removal from proxy e.g. when we call `poll()`
and leave the server running.