### PR TITLE
Proposed asynchronous dummy version of execute method

### DIFF
--- a/tests/async_execute_dummy.py
+++ b/tests/async_execute_dummy.py
@@ -1,0 +1,53 @@
+import asyncio, os
+
+async def async_execute_dummy(command):
+
+    # Have to change the environment manually before running the process.
+    # asyncio.subprocess.Process does not have an `env` attribute, the way subprocess.Popen does.
+    backup_env = os.environ.copy()
+    # Want a copy by value, not reference
+    ssh_env = backup_env.copy()
+    
+    ssh_env['X509_USER_CERT'] = 'cert'
+    ssh_env['X509_USER_KEY'] = 'key'
+    
+    os.environ.update(ssh_env)
+    
+    try:
+        proc = await asyncio.create_subprocess_shell(command, 
+                                                    stdout=asyncio.subprocess.PIPE, 
+                                                    stderr=asyncio.subprocess.PIPE)
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+        except asyncio.TimeoutError:
+            proc.kill()
+            stdout, stderr = await proc.communicate()
+        returncode = proc.returncode
+    
+    # Even if the above fails, we still want our environment variables reset and cleared of sensitive information.
+    finally:
+        os.environ.clear()
+        os.environ.update(backup_env)
+    
+    return (stdout, stderr, returncode)
+
+# Some smoke tests. I did more than are included here, some of which:
+    # (a) involve changing the return value of the function to include proc,
+    # (b) involve changing the timeout to be so miniscule that the timeout exception is invoked.
+
+print(os.environ)
+
+loop = asyncio.get_event_loop()
+
+try:
+    stdout, stderr, returncode = loop.run_until_complete(async_execute_dummy('/bin/sh echo "test"'))
+    
+finally:
+    loop.close()
+
+print(stdout)
+print(stderr)
+print(returncode)
+
+# Should be the same as before
+print(os.environ)

--- a/tests/execute_dummy.py
+++ b/tests/execute_dummy.py
@@ -1,0 +1,36 @@
+import subprocess, os
+
+def execute_dummy(command):
+    
+    ssh_env = os.environ.copy()
+    
+    ssh_env['X509_USER_CERT'] = 'cert'
+    ssh_env['X509_USER_KEY'] = 'key'
+    
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                     shell=True, env=ssh_env)
+    
+    try:
+        stdout, stderr = proc.communicate(timeout=10)
+    except subprocess.TimeoutError:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+    
+    returncode = proc.returncode
+    
+    return (stdout, stderr, returncode) 
+
+# Some smoke tests. I did more than are included here, some of which:
+    # (a) involve changing the return value of the function to include proc,
+    # (b) involve changing the timeout to be so miniscule that the timeout exception is invoked.
+
+print(os.environ)
+
+stdout, stderr, returncode = execute_dummy('/bin/sh echo "test"')
+
+print(stdout)
+print(stderr)
+print(returncode)
+
+# Should be the same as before
+print(os.environ)


### PR DESCRIPTION
Added two dummy versions of the `execute` method, one synchronous and one asynchronous, as well as some smoke tests for them and comments describing more smoke tests.

The idea is to confirm that `execute_dummy` has essentially the basic ideas of the *real* `execute` method, and that therefore `async_execute_dummy` does as well. Since it is straightforward to modify `execute_dummy` to be the same as the real `execute`, having that confirmation would make it straightforward to create an asynchronous version of the real `execute`.

Note that I used the native Python coroutines instead of `tornado.gen.coroutine` decorators for at least three reasons: 

1. They also had several undesirable implementation features which I can go into more detail about if you care.
2. Even the Tornado project now considers the `tornado.gen.coroutine` decorators to be deprecated.
3. The JupyterHub team uses the native Python coroutines, so using `torando.gen.coroutine` decorators would make the `sshspawner` code deprecated.

If it is possible to get this to work with the native Python coroutines (based on my simplistic smoke tests it should be), then afterwards I can make a pull request on `BatchSpawner` to use, for his `run_command` method, native Python coroutines instead of a `tornado.gen.coroutine` decorator.