### PR TITLE
Multiple possible remote hosts

### DIFF
--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -15,8 +15,9 @@ class SSHSpawner(Spawner):
     # http://traitlets.readthedocs.io/en/stable/migration.html#separation-of-metadata-and-keyword-arguments-in-traittype-contructors
     # config is an unrecognized keyword
 
-    nodes = List(trait=Unicode(), default_value=['Cori19','Cori20'],
-            help="Possible remote hosts from which to choose remote_host.").tag(config=True)
+    remote_hosts = List(trait=Unicode(),
+            help="Possible remote hosts from which to choose remote_host.",
+            config=True)
 
     # Removed 'config=True' tag.
     # Any user configureation of remote_host is redundant.
@@ -25,13 +26,16 @@ class SSHSpawner(Spawner):
             help="SSH remote host to spawn sessions on")
 
     remote_port = Unicode("22",
-            help="SSH remote port number").tag(config=True)
+            help="SSH remote port number",
+            config=True)
 
     ssh_command = Unicode("/usr/bin/ssh",
-            help="Actual SSH command").tag(config=True)
+            help="Actual SSH command",
+            config=True)
 
     path = Unicode("/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
-            help="Default PATH (should include jupyter and python)").tag(config=True)
+            help="Default PATH (should include jupyter and python)",
+            config=True)
 
     # The get_port.py script is in scripts/get_port.py
     # FIXME See if we avoid having to deploy a script on remote side?
@@ -40,41 +44,47 @@ class SSHSpawner(Spawner):
     # If we were fancy it could be configurable so it could be restricted
     # to specific ports.
     remote_port_command = Unicode("/usr/local/bin/get_port.py",
-            help="Command to return unused port on remote host").tag(config=True)
+            help="Command to return unused port on remote host",
+            config=True)
 
     # FIXME Fix help, what happens when not set?
     hub_api_url = Unicode("",
             help=dedent("""If set, Spawner will configure the containers to use
             the specified URL to connect the hub api. This is useful when the
             hub_api is bound to listen on all ports or is running inside of a
-            container.""")).tag(config=True)
+            container."""),
+            config=True)
 
     ssh_keyfile = Unicode("~/.ssh/id_rsa",
             help=dedent("""Key file used to authenticate hub with remote host.
             Assumes use_gsi=False. (use_gsi=False is deprecated)
 
             `~` will be expanded to the user's home directory and `{username}`
-            will be expanded to the user's username""")).tag(config=True)
+            will be expanded to the user's username"""),
+            config=True)
 
     # DEPRECATED
     use_gsi = Bool(False,
             help="""Use GSI authentication instead of SSH keys. Assumes you
             have a cert/key pair at the right path. Use in conjunction with
-            GSIAuthenticator. (Deprecated)""").tag(config=True)
+            GSIAuthenticator. (Deprecated)""",
+            config=True)
 
     gsi_cert_path = Unicode("/tmp/x509_{username}",
             help=dedent("""GSI certificate used to authenticate hub with remote
             host.  Assumes use_gsi=True. (Deprecated)
 
             `~` will be expanded to the user's home directory and `{username}`
-            will be expanded to the user's username""")).tag(config=True)
+            will be expanded to the user's username"""),
+            config=True)
 
     gsi_key_path = Unicode("/tmp/x509_{username}",
              help=dedent("""GSI key used to authenticate hub with remote host.
              Assumes use_gsi=True. (Deprecated)
 
              `~` will be expanded to the user's home directory and `{username}`
-             will be expanded to the user's username""")).tag(config=True)
+             will be expanded to the user's username"""),
+            config=True)
 
     pid = Integer(0,
             help=dedent("""Process ID of single-user server process spawned for
@@ -202,11 +212,11 @@ class SSHSpawner(Spawner):
         """Map JupyterHub username to remote username."""
         return username
 
-    def choose_remote_host(self):
+    async def choose_remote_host(self):
         """
         Given the list of possible nodes from which to choose, make the choice of which should be the remote host.
         """
-        remote_host = random.choice(self.nodes)
+        remote_host = random.choice(self.remote_hosts)
         return remote_host
 
     @observe('remote_host')

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -212,11 +212,11 @@ class SSHSpawner(Spawner):
         """Map JupyterHub username to remote username."""
         return username
 
-    async def choose_remote_host(self):
+    def choose_remote_host(self):
         """
         Given the list of possible nodes from which to choose, make the choice of which should be the remote host.
         """
-        remote_host = await random.choice(self.remote_hosts)
+        remote_host = random.choice(self.remote_hosts)
         return remote_host
 
     @observe('remote_host')

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -10,22 +10,21 @@ from jupyterhub.spawner import Spawner
 
 
 class SSHSpawner(Spawner):
+
+    # http://traitlets.readthedocs.io/en/stable/migration.html#separation-of-metadata-and-keyword-arguments-in-traittype-contructors
+    # config is an unrecognized keyword
     
     remote_host = Unicode("remote_host",
-            help="SSH remote host to spawn sessions on",
-            config=True)
+            help="SSH remote host to spawn sessions on").tag(config=True)
 
     remote_port = Unicode("22",
-            help="SSH remote port number",
-            config=True)
+            help="SSH remote port number").tag(config=True)
 
     ssh_command = Unicode("/usr/bin/ssh",
-            help="Actual SSH command",
-            config=True)
+            help="Actual SSH command").tag(config=True)
 
     path = Unicode("/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
-            help="Default PATH (should include jupyter and python)",
-            config=True)
+            help="Default PATH (should include jupyter and python)").tag(config=True)
 
     # The get_port.py script is in scripts/get_port.py
     # FIXME See if we avoid having to deploy a script on remote side?
@@ -34,47 +33,41 @@ class SSHSpawner(Spawner):
     # If we were fancy it could be configurable so it could be restricted
     # to specific ports.
     remote_port_command = Unicode("/usr/local/bin/get_port.py",
-            help="Command to return unused port on remote host",
-            config=True)
+            help="Command to return unused port on remote host").tag(config=True)
 
     # FIXME Fix help, what happens when not set?
     hub_api_url = Unicode("",
             help=dedent("""If set, Spawner will configure the containers to use
             the specified URL to connect the hub api. This is useful when the
             hub_api is bound to listen on all ports or is running inside of a
-            container."""),
-            config=True)
+            container.""")).tag(config=True)
 
     ssh_keyfile = Unicode("~/.ssh/id_rsa",
             help=dedent("""Key file used to authenticate hub with remote host.
             Assumes use_gsi=False. (use_gsi=False is deprecated)
 
             `~` will be expanded to the user's home directory and `{username}`
-            will be expanded to the user's username"""),
-            config=True)
+            will be expanded to the user's username""")).tag(config=True)
 
     # DEPRECATED
     use_gsi = Bool(False,
             help="""Use GSI authentication instead of SSH keys. Assumes you
             have a cert/key pair at the right path. Use in conjunction with
-            GSIAuthenticator. (Deprecated)""",
-            config=True)
+            GSIAuthenticator. (Deprecated)""").tag(config=True)
 
     gsi_cert_path = Unicode("/tmp/x509_{username}",
             help=dedent("""GSI certificate used to authenticate hub with remote
             host.  Assumes use_gsi=True. (Deprecated)
 
             `~` will be expanded to the user's home directory and `{username}`
-            will be expanded to the user's username"""),
-            config=True)
+            will be expanded to the user's username""")).tag(config=True)
 
     gsi_key_path = Unicode("/tmp/x509_{username}",
              help=dedent("""GSI key used to authenticate hub with remote host.
              Assumes use_gsi=True. (Deprecated)
 
              `~` will be expanded to the user's home directory and `{username}`
-             will be expanded to the user's username"""),
-             config=True)
+             will be expanded to the user's username""")).tag(config=True)
 
     pid = Integer(0,
             help=dedent("""Process ID of single-user server process spawned for
@@ -330,7 +323,7 @@ class SSHSpawner(Spawner):
             commands = split_into_arguments(self, command)
             # the variable stdin above is the path to a shell script, but what the process requires as stdin is the content of the file itself as a buffer/bytes
             stdin = open(stdin, "rb")
-            # it ^ might be better if this were an asyncio.streamwriter or asyncio.subprocess.PIPE, but this still works -- consider it a proof of concept.
+            # ^ might be better if this were an asyncio.streamwriter or asyncio.subprocess.PIPE. This might be (slightly) blocking.
 
                         
         else:

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -216,7 +216,7 @@ class SSHSpawner(Spawner):
         """
         Given the list of possible nodes from which to choose, make the choice of which should be the remote host.
         """
-        remote_host = random.choice(self.remote_hosts)
+        remote_host = await random.choice(self.remote_hosts)
         return remote_host
 
     @observe('remote_host')

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -332,11 +332,6 @@ class SSHSpawner(Spawner):
             stdin = open(stdin, "rb")
             # it ^ might be better if this were an asyncio.streamwriter or asyncio.subprocess.PIPE, but this still works -- consider it a proof of concept.
 
-            proc = await asyncio.create_subprocess_exec(*commands,
-                                            stdin=stdin, 
-                                            stdout=asyncio.subprocess.PIPE, 
-                                            stderr=asyncio.subprocess.PIPE,
-                                            env=ssh_env)
                         
         else:
             command = "{ssh_command} {flags} {hostname} bash -c '{command}'".format(
@@ -347,10 +342,12 @@ class SSHSpawner(Spawner):
 
             commands = split_into_arguments(self, command)
 
-            proc = await asyncio.create_subprocess_exec(*commands,
-                                            stdout=asyncio.subprocess.PIPE, 
-                                            stderr=asyncio.subprocess.PIPE,
-                                            env=ssh_env)
+        proc = await asyncio.create_subprocess_exec(*commands,
+                                                        stdin=stdin, 
+                                                        stdout=asyncio.subprocess.PIPE, 
+                                                        stderr=asyncio.subprocess.PIPE,
+                                                        env=ssh_env)
+
         
         # DRY
         def log_process(self, returncode, stdout, stderr):

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 import warnings
 import random
 
-from traitlets import Bool, Unicode, Integer, List
+from traitlets import Bool, Unicode, Integer, List, observe
 
 from jupyterhub.spawner import Spawner
 


### PR DESCRIPTION
Simple changes to SSHSpawner to enable multiple choices of remote host. Basically consists of adding one line to the `start` method and adding a new `choose_remote_host` method.

The actual choices of possible remote hosts have to be implemented in the `jupyterhub_config.py` file.

So far it hasn't been possible to test the changes based on the current master version of SSHSpawner. However, the changes did work without issue when they were applied to an earlier version of SSHSpawner, see here: https://github.com/krinsman/multi-node-sshspawner/commits/master

Also, in the future, one could conceivably expand/alter the `choose_remote_host` method quite easily to achieve, for example, a load-balancing scheme. 