### PR TITLE
What I believe to be ASCII art fix.

### DIFF
--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -246,7 +246,9 @@ class SSHSpawner(Spawner):
         stdout, stderr, retcode = await self.execute(command)
 
         if stdout != b"":
-            port = int(stdout)
+            # ASCII art fix: turn bytes to string, strip whitespace, split along newlines, grab last line of STDOUT.
+            # Assumption: The last line of STDOUT should always be output of get_port.py, ASCII art or not.
+            port = int(stdout.decode().strip().split("\n")[-1])
             self.log.debug("port={}".format(port))
         else:
             port = None

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -248,6 +248,7 @@ class SSHSpawner(Spawner):
         if stdout != b"":
             # ASCII art fix: turn bytes to string, strip whitespace, split along newlines, grab last line of STDOUT.
             # Assumption: The last line of STDOUT should always be output of get_port.py, ASCII art or not.
+            # Assumption: The last line of the STDOUT created by get_port.py is always the port number.
             port = int(stdout.decode().strip().split("\n")[-1])
             self.log.debug("port={}".format(port))
         else:


### PR DESCRIPTION
Even if this doesn't fix the error (pretty confident based on local testing that it does though), it can't be breaking (knock on wood), because for the good cases it still gives the exact same output. E.g.

```
test = lambda x : int(x.decode().strip().split("\n")[-1])
test(b'12345') == int(b'12345')
test(b'12345\n') == int(b'12345\n')
test(b'\n12345\n) == int(b'\n12345\n')
```
```
True
True
True
```

For a more extensive local test, first copy [`get_port.py`](https://github.com/NERSC/jupyterhub-deploy/blob/master/jupyter-sshspawner/app/get_port.py) to your login folder on `self.remote_host`, and have the following Python script `test_script.py` in your pwd (like sshspawner requires at least Python 3.5; also of course the script needs to be made executable with `chmod +x`):

```
#!<which python>
import sys, asyncio

print("System's STDIN")
print(sys.stdin + "\n")

# Can't pass a TextIOWrapper directly as argument for `stdin` in `create_subprocess_exec`
data = sys.stdin.read()

loop = asyncio.get_event_loop()
pipe = asyncio.subprocess.PIPE

# Compare with: https://github.com/NERSC/sshspawner/blob/master/sshspawner/sshspawner.py#L369
proc = loop.run_until_complete(asyncio.create_subprocess_exec('cat', stdin=pipe, stdout=pipe, stderr=pipe))
# Compare with: https://github.com/NERSC/sshspawner/blob/master/sshspawner/sshspawner.py#L246
stdout, stderr = loop.run_until_complete(proc.communicate(input=data.encode()))

result = int(stdout.decode().strip().split("\n")[-1])
print("This is supposed to be the end result.\n")
print(result)

loop.close()
```
<sub>Replace `<which python>` with the output of `which python` in the terminal.</sub>

Then run the following in the terminal* (compare with [here](https://github.com/NERSC/sshspawner/blob/master/sshspawner/sshspawner.py#L361)):

```
`self.ssh_command` `ssh_args` `self.remote_host` bash -c '"./get_port.py" < /dev/null' > temp.txt
cat temp.txt | test_script.py
```

<sub>The backticks are supposed to represent values one needs to fill in themselves.</sub>

Even if you add the following lines to your BASH profile _on the remote host_:

```
echo "(@@) (  ) (@)  ( )  @@    ()    @     O     @                  (   )
                 (@@@@)
              (    )

            (@@@)
         ====        ________                ___________
     _D _|  |_______/        \__I_I_____===__|_________|
      |(_)---  |   H\________/ |   |        =|___ ___|      ________________
      /     |  |   H  |  |     |   |         ||_| |_||     _|
     |      |  |   H  |__--------------------| [___] |   =|
     | ________|___H__/__|_____/[][]~\_______|       |   -|
     |/ |   |-----------I_____I [][] []  D   |=======|____|_________________
   __/ =| o |=-O=====O=====O=====O \ ____Y___________|__|___________________
    |/-=|___|=    ||    ||    ||    |_____/~\___/          |_D__D__D_|  |_D_
     \_/      \__/  \__/  \__/  \__/      \_/               \_/   \_/    \_/"
```

the above should still work.

<sub>*Since piping doesn't execute the commands sequentially, [I believe](https://unix.stackexchange.com/a/37597), piping the SSH command directly into the Python script doesn't work, since then the script runs before you ever even log in to the remote host, voiding the purpose of doing this.</sub>