### PR TITLE
Allows us to return remote side IP

### DIFF
--- a/scripts/get_port.py
+++ b/scripts/get_port.py
@@ -1,9 +1,35 @@
 #!/usr/bin/python
 
-# Gets a random unused port
-
+import argparse
 import socket
-sock = socket.socket()
-sock.bind(('', 0))
-print sock.getsockname()[1]
-sock.close()
+
+def main():
+    args = parse_arguments()
+    if args.ip:
+        print("{} {}".format(port(), ip()))
+    else:
+        print(port())
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ip", "-i",
+            help="Include IP address in output",
+            action="store_true")
+    return parser.parse_args()
+
+def port():
+    s = socket.socket()
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+def ip(address=("8.8.8.8", 80)):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(address)
+    ip = s.getsockname()[0]
+    s.close()
+    return ip
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
If the remote host is behind a load balancer, `get_port.py` should return its IP address.  At any rate, since 0.9 spawners are supposed to return `(ip, port)` and this allows us to do that.

I think also SSHSpawner should not just call this without prefixing a specific Python path, and we should get rid of the `#!/usr/bin/python` altogether but that can be done in a separate PR.