### PR TITLE
Require invocation of Python and clearly document

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -13,5 +13,5 @@ c.SSHSpawner.use_gsi = True
 c.SSHSpawner.path = '/global/common/cori/software/python/3.5-anaconda/bin:/global/common/cori/das/jupyterhub/:/usr/common/usg/bin:/usr/bin:/bin:/usr/bin/X11:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin'
 
 # The command to return an unused port on the target system. See scripts/get_port.py for an example
-c.SSHSpawner.remote_port_command = '/global/common/cori/das/jupyterhub/get_port.py'
+c.SSHSpawner.remote_port_command = '/usr/bin/python /global/common/cori/das/jupyterhub/get_port.py'
 

--- a/scripts/get_port.py
+++ b/scripts/get_port.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 # Gets a random unused port
 

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -43,7 +43,7 @@ class SSHSpawner(Spawner):
     # as a package and have it put get_port.py in the right place.
     # If we were fancy it could be configurable so it could be restricted
     # to specific ports.
-    remote_port_command = Unicode("/usr/local/bin/get_port.py",
+    remote_port_command = Unicode("/usr/bin/python /usr/local/bin/get_port.py",
             help="Command to return unused port on remote host",
             config=True)
 


### PR DESCRIPTION
It doesn't seem wise to me to put the specific path to Python, or even use `#!/usr/bin/env python` at the top of `get_port.py` so I have taken it out and updated the example config so that a specific Python interpreter has to be invoked. 