### PR TITLE
It's time for named servers via UI at NERSC

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -13,5 +13,5 @@ c.SSHSpawner.use_gsi = True
 c.SSHSpawner.path = '/global/common/cori/software/python/3.5-anaconda/bin:/global/common/cori/das/jupyterhub/:/usr/common/usg/bin:/usr/bin:/bin:/usr/bin/X11:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin'
 
 # The command to return an unused port on the target system. See scripts/get_port.py for an example
-c.SSHSpawner.remote_port_command = '/global/common/cori/das/jupyterhub/get_port.py'
+c.SSHSpawner.remote_port_command = '/usr/bin/python /global/common/cori/das/jupyterhub/get_port.py'
 

--- a/scripts/get_port.py
+++ b/scripts/get_port.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import argparse
 import socket

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -43,7 +43,7 @@ class SSHSpawner(Spawner):
     # as a package and have it put get_port.py in the right place.
     # If we were fancy it could be configurable so it could be restricted
     # to specific ports.
-    remote_port_command = Unicode("/usr/local/bin/get_port.py",
+    remote_port_command = Unicode("/usr/bin/python /usr/local/bin/get_port.py",
             help="Command to return unused port on remote host",
             config=True)
 

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -115,20 +115,11 @@ class SSHSpawner(Spawner):
         super().clear_state()
         self.pid = 0
 
-    # FIXME this looks like it's done differently now, there is get_env which
-    # actually calls this.
-    def user_env(self):
+    def get_env(self):
         """Augment env of spawned process with user-specific env variables."""
-
-        # FIXME I think the JPY_ variables have been deprecated in JupyterHub
-        # since 0.7.2, we should replace them.  Can we figure this out?
 
         env = super(SSHSpawner, self).get_env()
         env.update(dict(
-            JPY_USER=self.user.name,
-            JPY_COOKIE_NAME=self.user.server.cookie_name,
-            JPY_BASE_URL=self.user.server.base_url,
-            JPY_HUB_PREFIX=self.hub.server.base_url,
             JUPYTERHUB_PREFIX=self.hub.server.base_url,
             PATH=self.path
         ))
@@ -140,7 +131,6 @@ class SSHSpawner(Spawner):
         if self.hub_api_url != '':
             hub_api_url = self.hub_api_url
 
-        env['JPY_HUB_API_URL'] = hub_api_url
         env['JUPYTERHUB_API_URL'] = hub_api_url
 
         return env
@@ -260,7 +250,7 @@ class SSHSpawner(Spawner):
     async def exec_notebook(self, command):
         """TBD"""
 
-        env = self.user_env()
+        env = self.get_env()
         bash_script_str = "#!/bin/bash\n"
 
         for item in env.items():


### PR DESCRIPTION
This PR modernizes one of the methods of SSHSpawner. 

Specifically, this PR deletes the deprecated `user_env` method and deprecated `JPY_` environment variables as per the FIXME. This PR also extends the `get_env` method from the parent class to implement the functionality which would otherwise be lost by deleting `user_env`. 

In particular, setting the `JPY_` environment variables does not appear to do anything different from the parent class's `get_env`, so it seemed safe to delete them without adding any explicit replacements (their implicit replacements are [here](https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/spawner.py#L609)).

In doing this, this PR also makes SSHSpawner compatible with UI named servers as implemented here: https://github.com/jupyterhub/jupyterhub/pull/2089 (which to my surprise actually passed the Travis build tests!)