### PR TITLE
Fixes with JupyterHub 2.3.1

### DIFF
--- a/scripts/get_port.py
+++ b/scripts/get_port.py
@@ -1,27 +1,13 @@
-
-import argparse
 import socket
 
-def main():
-    args = parse_arguments()
-    if args.ip:
-        print("{} {}".format(port(), ip()))
-    else:
-        print(port())
-
-def parse_arguments():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--ip", "-i",
-            help="Include IP address in output",
-            action="store_true")
-    return parser.parse_args()
 
 def port():
     s = socket.socket()
-    s.bind(('', 0))
+    s.bind(("", 0))
     port = s.getsockname()[1]
     s.close()
     return port
+
 
 def ip(address=("8.8.8.8", 80)):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -30,5 +16,6 @@ def ip(address=("8.8.8.8", 80)):
     s.close()
     return ip
 
+
 if __name__ == "__main__":
-    main()
+    print(f"{ip()} {port()}")

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -152,9 +152,16 @@ class SSHSpawner(Spawner):
             for index, value in enumerate(cmd):
                 if value == old:
                     cmd[index] = new
+
+        has_port = False
         for index, value in enumerate(cmd):
             if value[0:6] == '--port':
                 cmd[index] = '--port=%d' % (port)
+                has_port = True
+
+        # Always supply port option!
+        if not has_port:
+            cmd.append(f"--port={port}")
 
         remote_cmd = ' '.join(cmd)
 

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -267,7 +267,7 @@ class SSHSpawner(Spawner):
         for item in env.items():
             # item is a (key, value) tuple
             # command = ('export %s=%s;' % item) + command
-            bash_script_str += 'export %s="%s"\n' % item
+            bash_script_str += "export %s='%s'\n" % item
         bash_script_str += 'unset XDG_RUNTIME_DIR\n'
 
         bash_script_str += 'touch .jupyter.log\n'

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -16,6 +16,9 @@ class SSHSpawner(Spawner):
     # http://traitlets.readthedocs.io/en/stable/migration.html#separation-of-metadata-and-keyword-arguments-in-traittype-contructors
     # config is an unrecognized keyword
 
+    # Change default ip value for SSHSpawners
+    ip = "0.0.0.0"
+
     remote_hosts = List(trait=Unicode(),
             help="Possible remote hosts from which to choose remote_host.",
             config=True)
@@ -114,7 +117,7 @@ class SSHSpawner(Spawner):
         c = asyncssh.read_certificate(cf)
 
         self.remote_host = self.choose_remote_host()
-        
+
         self.remote_ip, port = await self.remote_random_port()
         if self.remote_ip is None or port is None or port == 0:
             return False
@@ -211,8 +214,8 @@ class SSHSpawner(Spawner):
 
     # FIXME this needs to now return IP and port too
     async def remote_random_port(self):
-        """Select unoccupied port on the remote host and return it. 
-        
+        """Select unoccupied port on the remote host and return it.
+
         If this fails for some reason return `None`."""
 
         username = self.get_remote_user(self.user.name)

--- a/sshspawner/sshspawner.py
+++ b/sshspawner/sshspawner.py
@@ -267,7 +267,7 @@ class SSHSpawner(Spawner):
         for item in env.items():
             # item is a (key, value) tuple
             # command = ('export %s=%s;' % item) + command
-            bash_script_str += 'export %s=%s\n' % item
+            bash_script_str += 'export %s="%s"\n' % item
         bash_script_str += 'unset XDG_RUNTIME_DIR\n'
 
         bash_script_str += 'touch .jupyter.log\n'


### PR DESCRIPTION
This PR includes changes I made in my fork to get SSHSpawner to work with JupyterHub 2.3.1 in my [personal Docker-based testing environment](https://github.com/ncar-xdev/binder-hpc).  There are not many source-code changes, so I will describe them all:

- [Simplify since ip and port always required now](https://github.com/NERSC/sshspawner/commit/6045a64f0e5c8bbadd38e5b577099be63938fb06): This is a simplification of the `get_port.py` script.  Since the latest versions of JupyterHub seem to require both `ip` and `port` be specified (and in that order), I just simplified the script to *always* return the `(ip, port)` tuple.  However, maybe we want backwards compatibility, in which case this should probably be reverted/modified.

- [Change default IP for all SSHSpawners](https://github.com/NERSC/sshspawner/commit/736970325077f28add53448f3583802341ee9e19): By default, JupyterHub Spawners have a default `ip` of `127.0.0.1`, which will not work for any remote singleuser instance.  According to the [JupyterHub documentation](https://jupyterhub.readthedocs.io/en/stable/reference/spawners.html?highlight=Spawner.ip#note-on-ips-and-ports), remote Spawners should use an `ip` value of `0.0.0.0`.  I cannot think of an instance where an SSHSpawner would not be remote (otherwise why not just use LocalProcessSpawner?), so I've changed the default `ip` value to `0.0.0.0`.

- [Always set the port](https://github.com/NERSC/sshspawner/commit/fef4df497b112c12b3052fa33d777cb7bee95a09): SSHSpawner relies on the separate `get_port.py` script to determine the port on the remote system to listen on, which means the remote port number needs to be passed to the singleuser instance.  So, I figure you probably always want the `--port` option set.

- [Wrap all env vars in quotes to ensure JSON encoding](https://github.com/NERSC/sshspawner/commit/baf937157705ea59a75ef8edf3e42802b0107721) & [Need single quote to wrap JSON](https://github.com/NERSC/sshspawner/commit/6bba9718a92d3e78eccbf2ce9e972a6cbf9c2f68): There are `JUPYTERHUB_*` environment variables sent to the spawned process that contain JSON data, and the previous setting/exporting of those environment variables in SSHSpawner's bash run script did not encase this JSON in quotes, just leading to improperly set environment variables.  For safety's sake, I have wrapped all of the environment variables used in the SSHSpawner run script with single quotes.  Something more sophisticated may be needed if this is not always sufficient.

In additiion to these source-code changes, I had to make one additions to the `jupyterhub_config.py` file to allow SSHSpawner to work.  This change was:

```python
c.SSHSpawner.hub_api_url = f"http://{c.JupyterHub.hub_connect_ip}:8081/hub/api"
```

I am not sure if this suggests a modification needs to be made to SSHSpawner that I have not made.  It seems to me that there should be an automated was of constructing the SSHSpawner's `hub_api_url` from information already known.  I just haven't investigated this, yet.

I completely understand if these changes are not what you want implemented in SSHSpawner.  I just wanted to share them with you to demonstrate what I needed to do to get it to work with JupyterHub 2.3.1 (latest version).